### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-This charm deploy and manage [Capsule](https://github.com/clastix/capsule) on Kubernetes.
+**Capsule** implements a multi-tenant and policy-based  environment in your Kubernetes cluster. It is designed as a  micro-services-based ecosystem with the minimalist approach, leveraging  only on upstream Kubernetes.
 
-The Capsule operator is a Python script that wrap the latest released version of Capsule, providing life-cycle management and handling events such as install, upgrade, integrate, and remove.
+This repository contains a Charm Operator for deploying **Capsule** in a Charmed Kubernetes cluster.
 
 ## Usage
 
@@ -24,8 +24,9 @@ juju deploy --trust ./charm-k8s-capsule.charm --resource capsule-image=clastix/c
 To configure the charm, run:
 
 ```bash
-juju config charm-k8s-capsule key=value
-# Example: juju config charm-k8s-capsule force-tenant-prefix=true
+# Example: juju config charm-k8s-capsule key=value
+juju config charm-k8s-capsule force-tenant-prefix=true
+juju config charm-k8s-capsule user-groups=capsule.clastix.io,gas.clastix.io,oil.clastix.io
 ```
 
 In case you have multiple `CapsuleConfiguration` instances, you can modify a specific one by using the `capsule-configuration-name` parameter with the name of the resource you want to modify:
@@ -34,5 +35,20 @@ In case you have multiple `CapsuleConfiguration` instances, you can modify a spe
 juju config charm-k8s-capsule capsule-configuration-name=capsule-configuration-2 force-tenant-prefix=true
 ```
 
-For available parameters, take a look at `config.yaml` file in this repository.
+The configurable parameters are:
+
+| **name**                    | **description**                                              | type    | **default**          | references                                                   |
+| --------------------------- | ------------------------------------------------------------ | ------- | -------------------- | ------------------------------------------------------------ |
+| `user-groups`               | Comma-separated list of user groups (example: `oil.capsule.io,gas.capsule.io`). | string  | `capsule.clastix.io` | [userGroups](https://capsule.clastix.io/docs/general/references/#capsule-configuration) |
+| `force-tenant-prefix`       | Force to have a tenant prefix.                               | boolean | `false`              | [forceTenantPrefix](https://capsule.clastix.io/docs/general/references/#capsule-configuration) |
+| `protected-namespace-regex` | Disallows creation of namespaces matching the passed regexp. | string  | `""`                 | [protectedNamespaceRegex](https://capsule.clastix.io/docs/general/references/#capsule-configuration) |
+
+## References
+
+* [Capsule](https://github.com/clastix/capsule)
+* [OCI Image](https://quay.io/repository/clastix/capsule?tab=tags&tag=latest)
+
+## Documentation
+
+Read the official documentation here: [capsule.clastix.io](https://capsule.clastix.io/)
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,25 +10,25 @@
 options:
   name:
     default: capsule
-    description: Multi Tenant Operator
+    description: "Multi Tenant Operator"
     type: string
   namespace:
     default: capsule-system
-    description: Capsule system namespace.
+    description: "Capsule system namespace."
     type: string
   capsule-configuration-name:
     default: capsule-default
-    description: Capsule Configuration name.
+    description: "Capsule Configuration name."
     type: string
   user-groups:
     default: capsule.clastix.io
-    description: Comma-separated list of user groups (oil.capsule.io,gas.capsule.io,...).
+    description: "Comma-separated list of user groups (example: oil.capsule.io,gas.capsule.io,...)."
     type: string
   force-tenant-prefix:
     default: false
-    description: Force to have a tenant prefix.
+    description: "Force to have a tenant prefix."
     type: boolean
   protected-namespace-regex:
     default: ""
-    description: Disallows creation of namespaces matching the passed regexp.
+    description: "Disallows creation of namespaces matching the passed regexp."
     type: string

--- a/docs/development-env-setup.md
+++ b/docs/development-env-setup.md
@@ -1,0 +1,36 @@
+# Development Environment Setup
+
+After setting up the [test environment](https://github.com/clastix/charm-k8s-capsule/blob/master/docs/test-env-setup.md#local-environment-setup) to deploy your artifacts, you need a development environment to build and package the charms.
+
+Our suggestion is to create a separated VM with **Ubuntu 20.04** in order to have a better compatibility with **LXD** and other Canonical utilities.
+
+At first we have to download **snap**:
+
+```bash
+sudo apt update && apt install snapd
+```
+
+Let's install **LXD**:
+
+```bash
+sudo snap install lxd
+sudo adduser $USER lxd
+newgrp lxd
+lxd init --auto
+```
+
+Install **charmcraft** utility to build, package and upload our charm.
+
+```bash
+sudo snap install charmcraft --classic
+```
+
+Now we have all we need to start develop the charm. Upload the code on the development VM and build it.
+
+```bash
+cd /path/to/charm-project
+charmcraft pack
+```
+
+So you will have the **charm** inside the project directory, ready to be deployed with **juju**.
+

--- a/docs/test-env-setup.md
+++ b/docs/test-env-setup.md
@@ -1,4 +1,4 @@
-# Environment Setup
+# Test Environment Setup
 
 This guide will show you how to create a local installation of **Charmed Kubernetes**.
 


### PR DESCRIPTION
Fix #10.
In this PR I added:
* list of configurable parameters using `juju`.
* development environmet setup with command to build and pack the charm.
* some tips to use the operator.

I provided a basic documentation, getting inspiration by the other charm repositories:
* https://github.com/jnsgruk/kubernetes-dashboard-operator
* https://git.launchpad.net/charm-k8s-discourse/tree/
* https://github.com/canonical/bundle-kubeflow
* https://github.com/canonical/minio-operator/

As you can see they are really minimal, and "documentation" is extracted from files like `metadata.yaml` and `config.yaml` in their charmhub page:
* https://charmhub.io/discourse-k8s
* https://charmhub.io/elasticsearch-k8s